### PR TITLE
Add advanced fuel metrics in decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,25 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Raw Telemetry Decoder
+
+This repository includes a small example script that decodes simplified raw
+telemetry values from a text file and exposes them on the same WebSocket used by
+the overlays.
+
+1. Edit `sample-raw.txt` adding lines formatted as `Key:Value` pairs separated by
+   spaces (for example: `Speed:120 RPM:6500 FuelLevel:45 FuelPerLap:2.5`).
+2. Run the decoder with `node tools/raw-decoder.js sample-raw.txt`.
+3. Overlays can connect to `ws://localhost:5221/ws` to receive the parsed data.
+
+The decoder also computes a few derived values:
+
+- `CurrentFuelPerLap` – the latest `FuelPerLap` value.
+- `AvgFuelPerLap` – running average of fuel used each lap whenever a new `Lap`
+  value is detected.
+- `LapsRemainingCur` – estimated laps left using the current consumption.
+- `LapsRemainingAvg` – estimated laps left using the average consumption.
+
+If the raw lines contain fields like `S1`, `S2`, `S3`, they are exposed as a
+`SectorTimes` array for use by the overlays.

--- a/sample-raw.txt
+++ b/sample-raw.txt
@@ -1,0 +1,2 @@
+Lap:1 Speed:120 RPM:6500 FuelLevel:45 FuelPerLap:2.5 S1:30.5 S2:31.1 S3:32.0
+Lap:2 Speed:118 RPM:6400 FuelLevel:42.4 FuelPerLap:2.6 S1:30.6 S2:31.0 S3:31.9

--- a/tools/raw-decoder.js
+++ b/tools/raw-decoder.js
@@ -1,0 +1,85 @@
+import fs from 'fs';
+import { WebSocketServer } from 'ws';
+
+const FILE = process.argv[2] || 'sample-raw.txt';
+const PORT = 5221;
+const PATH = '/ws';
+
+const wss = new WebSocketServer({ port: PORT, path: PATH });
+const clients = new Set();
+
+wss.on('connection', ws => {
+  clients.add(ws);
+  ws.on('close', () => clients.delete(ws));
+});
+
+function parseLine(line) {
+  const obj = {};
+  line.trim().split(/\s+/).forEach(kv => {
+    const [key, val] = kv.split(':');
+    if (key) obj[key] = Number(val);
+  });
+  return obj;
+}
+
+let lastLap = null;
+let lastFuel = null;
+let totalFuelUsed = 0;
+let lapCount = 0;
+
+function calcExtras(t) {
+  const fuelUse = t.FuelPerLap || 0;
+  const fuelLeft = t.FuelLevel || 0;
+
+  if (typeof t.Lap === 'number') {
+    if (lastLap !== null && t.Lap !== lastLap) {
+      const diff = lastFuel !== null ? lastFuel - fuelLeft : 0;
+      if (diff > 0) {
+        totalFuelUsed += diff;
+        lapCount += 1;
+      }
+    }
+    lastLap = t.Lap;
+  }
+  if (typeof fuelLeft === 'number') {
+    lastFuel = fuelLeft;
+  }
+
+  const avgFuel = lapCount > 0 ? totalFuelUsed / lapCount : 0;
+
+  t.CurrentFuelPerLap = fuelUse;
+  t.AvgFuelPerLap = avgFuel;
+  t.LapsRemainingCur = fuelUse > 0 ? fuelLeft / fuelUse : 0;
+  t.LapsRemainingAvg = avgFuel > 0 ? fuelLeft / avgFuel : 0;
+
+  t.SectorTimes = [t.S1, t.S2, t.S3].filter(v => typeof v === 'number');
+
+  return t;
+}
+
+function broadcast(data) {
+  const payload = JSON.stringify(data);
+  for (const ws of clients) {
+    if (ws.readyState === ws.OPEN) ws.send(payload);
+  }
+}
+
+function watch() {
+  if (!fs.existsSync(FILE)) {
+    console.error(`File ${FILE} not found`);
+    return;
+  }
+  console.log(`Watching ${FILE} and serving WebSocket ws://localhost:${PORT}${PATH}`);
+  let lastSize = 0;
+  fs.watchFile(FILE, () => {
+    const stat = fs.statSync(FILE);
+    if (stat.size === lastSize) return;
+    lastSize = stat.size;
+    const lines = fs.readFileSync(FILE, 'utf8').trim().split(/\r?\n/);
+    const raw = parseLine(lines[lines.length - 1]);
+    const data = calcExtras(raw);
+    broadcast(data);
+  });
+}
+
+watch();


### PR DESCRIPTION
## Summary
- compute average/current fuel use and sector times in `raw-decoder.js`
- document the extra fields in README
- expand the sample raw file with lap info and sector data

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa3e6402c8330b540385f5d84f9c3